### PR TITLE
Add support for a defined entrypoint into web container

### DIFF
--- a/src/ansible/roles/flightdeck-web-init/tasks/main.yml
+++ b/src/ansible/roles/flightdeck-web-init/tasks/main.yml
@@ -46,5 +46,7 @@
   lineinfile:
     path: "/var/www/.bashrc"
     regexp: "^cd \\$HOME$"
-    line: "cd {{ flightdeck_web.vhosts[0].entrypoint | flightdeck_web.vhosts[0].docroot | default('$HOME') }}"
+    line: "cd {{ flightdeck_web.vhosts[0].entrypoint }}"
     state: present
+  when:
+  - flightdeck_web.vhosts[0].entrypoint is defined

--- a/src/ansible/roles/flightdeck-web-init/tasks/main.yml
+++ b/src/ansible/roles/flightdeck-web-init/tasks/main.yml
@@ -45,6 +45,4 @@
 - name: Update initial directory
   lineinfile:
     path: "/var/www/.bashrc"
-    line: "cd {{ flightdeck_web.initialDir }}"
-  when:
-  - flightdeck_web.initialDir is defined
+    line: "cd {{ flightdeck_web.initialDir | default('$HOME') }}"

--- a/src/ansible/roles/flightdeck-web-init/tasks/main.yml
+++ b/src/ansible/roles/flightdeck-web-init/tasks/main.yml
@@ -42,4 +42,9 @@
     owner: "apache"
     group: "apache"
     mode: "u=rw,g=r,o="
-
+- name: Update initial directory
+  lineinfile:
+    path: "/var/www/.bashrc"
+    regexp: "^cd \\$HOME$"
+    line: "cd {{ flightdeck_web.vhosts[0].entrypoint | flightdeck_web.vhosts[0].docroot | default('$HOME') }}"
+    state: present

--- a/src/ansible/roles/flightdeck-web-init/tasks/main.yml
+++ b/src/ansible/roles/flightdeck-web-init/tasks/main.yml
@@ -45,8 +45,6 @@
 - name: Update initial directory
   lineinfile:
     path: "/var/www/.bashrc"
-    regexp: "^cd \\$HOME$"
-    line: "cd {{ flightdeck_web.vhosts[0].entrypoint }}"
-    state: present
+    line: "cd {{ flightdeck_web.entry_point }}"
   when:
-  - flightdeck_web.vhosts[0].entrypoint is defined
+  - flightdeck_web.entry_point is defined

--- a/src/ansible/roles/flightdeck-web-init/tasks/main.yml
+++ b/src/ansible/roles/flightdeck-web-init/tasks/main.yml
@@ -45,6 +45,6 @@
 - name: Update initial directory
   lineinfile:
     path: "/var/www/.bashrc"
-    line: "cd {{ flightdeck_web.entry_point }}"
+    line: "cd {{ flightdeck_web.initialDir }}"
   when:
-  - flightdeck_web.entry_point is defined
+  - flightdeck_web.initialDir is defined


### PR DESCRIPTION
- Only runs when it's defined (or at least, it should) 
- Needs testing. 